### PR TITLE
Add InternalTransferCircuit to enable internal transfer.

### DIFF
--- a/Circuits/InternalTransferCircuit.h
+++ b/Circuits/InternalTransferCircuit.h
@@ -9,7 +9,6 @@
 
 #include "ethsnarks.hpp"
 #include "utils.hpp"
-#include "jubjub/point.hpp"
 
 using namespace ethsnarks;
 namespace Loopring
@@ -18,236 +17,266 @@ namespace Loopring
 class InternalTransferGadget : public GadgetT
 {
 public:
-    DualVariableGadget accountID_A; // from A
-    DualVariableGadget accountID_B; // to B
+
+    // User From state
+    BalanceGadget balanceFBefore_From;
+    BalanceGadget balanceTBefore_From;
+    AccountGadget accountBefore_From;
+    // User To state
+    BalanceGadget balanceTBefore_To;
+    AccountGadget accountBefore_To;
+    // Operator state
+    BalanceGadget balanceBefore_O;
+
+    // Inputs
+    DualVariableGadget accountID_From;
+    DualVariableGadget accountID_To;
+    DualVariableGadget tokenID;
+    DualVariableGadget amount;
     DualVariableGadget feeTokenID;
     DualVariableGadget fee;
-    DualVariableGadget transTokenID;
-    DualVariableGadget transAmount;
-
     VariableT label;
 
-    // User state
-    BalanceGadget balanceF_A_Before;  // A pays fee
-    BalanceGadget balanceT_A_Before;  // A transfers balance
-    BalanceGadget balanceT_B_Before;  // B receives balance
-    AccountGadget account_A_Before;
-    AccountGadget account_B_Before;
+    // User To account check
+    RequireNotZeroGadget publicKeyX_notZero;
 
-    // Operator state
-    BalanceGadget balanceF_O_Before;
-
-    // fee payment related gadgets
+    // Fee as float
     FloatGadget fFee;
-    RequireAccuracyGadget ensureAccuracyFee;
-    subadd_gadget feePayment;
+    RequireAccuracyGadget requireAccuracyFee;
+    // Amount as float
+    FloatGadget fAmount;
+    RequireAccuracyGadget requireAccuracyAmount;
 
-    // transfer payment related gadgets
-    FloatGadget fTransAmount;
-    RequireAccuracyGadget ensureAccuracyTransAmount;
+    // Fee payment from From to the operator
+    subadd_gadget feePayment;
+    // Transfer from From to To
     subadd_gadget transferPayment;
 
-    // Increase the nonce of the user by 1
-    AddGadget nonce_A_after;
+    // Increase the nonce of From by 1
+    AddGadget nonce_From_after;
 
-    UpdateBalanceGadget updateBalanceF_A;
-    UpdateBalanceGadget updateBalanceT_A;
-    UpdateAccountGadget updateAccount_A;
+    // Update User From
+    UpdateBalanceGadget updateBalanceF_From;
+    UpdateBalanceGadget updateBalanceT_From;
+    UpdateAccountGadget updateAccount_From;
 
-    UpdateBalanceGadget updateBalanceT_B;
-    UpdateAccountGadget updateAccount_B;
+    // Update User To
+    UpdateBalanceGadget updateBalanceT_To;
+    UpdateAccountGadget updateAccount_To;
 
+    // Update Operator
     UpdateBalanceGadget updateBalanceF_O;
 
+    // Signature
     Poseidon_gadget_T<10, 1, 6, 53, 9, 1> hash;
     SignatureVerifier signatureVerifier;
 
-    // constants
-    const VariableArrayT& dataPadding_0000;
-
     InternalTransferGadget(
         ProtoboardT &pb,
-        const jubjub::Params &params,
-        const Constants &constants,
-        const VariableT &_accountsMerkleRoot,
-        const VariableT &_operatorBalancesRoot,
-        const VariableT &blockExchangeID,
-        const std::string &prefix)
-        : GadgetT(pb, prefix),
+        const jubjub::Params& params,
+        const Constants& constants,
+        const VariableT& accountsMerkleRoot,
+        const VariableT& operatorBalancesRoot,
+        const VariableT& blockExchangeID,
+        const std::string &prefix
+    ) :
+        GadgetT(pb, prefix),
 
-          accountID_A(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".accountID_A")),
-          accountID_B(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".accountID_B")),
-          feeTokenID(pb, NUM_BITS_TOKEN, FMT(prefix, ".feeTokenID")),
-          fee(pb, NUM_BITS_AMOUNT, FMT(prefix, ".fee")),
-          transTokenID(pb, NUM_BITS_TOKEN, FMT(prefix, ".transTokenID")),
-          transAmount(pb, NUM_BITS_AMOUNT, FMT(prefix, ".transAmount")),
+        // User From state
+        balanceFBefore_From(pb, FMT(prefix, "balanceFBefore_From")),
+        balanceTBefore_From(pb, FMT(prefix, "balanceTBefore_From")),
+        accountBefore_From(pb, FMT(prefix, "accountBefore_From")),
+        // User To state
+        balanceTBefore_To(pb, FMT(prefix, "balanceTBefore_To")),
+        accountBefore_To(pb, FMT(prefix, "accountBefore_To")),
+        // Operator state
+        balanceBefore_O(pb, FMT(prefix, "balanceBefore_O")),
 
-          label(make_variable(pb, FMT(prefix, ".label"))),
+        // Inputs
+        accountID_From(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".accountID_From")),
+        accountID_To(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".accountID_To")),
+        tokenID(pb, NUM_BITS_TOKEN, FMT(prefix, ".tokenID")),
+        amount(pb, NUM_BITS_AMOUNT, FMT(prefix, ".amount")),
+        feeTokenID(pb, NUM_BITS_TOKEN, FMT(prefix, ".feeTokenID")),
+        fee(pb, NUM_BITS_AMOUNT, FMT(prefix, ".fee")),
+        label(make_variable(pb, FMT(prefix, ".label"))),
 
-          balanceF_A_Before(pb, FMT(prefix, "balanceF_A_Before")), // A pays fee
-          balanceT_A_Before(pb, FMT(prefix, "balanceT_A_Before")),
-          balanceT_B_Before(pb, FMT(prefix, "balanceT_B_Before")),
-          account_A_Before(pb, FMT(prefix, "account_A_Before")),
-          account_B_Before(pb, FMT(prefix, "account_B_Before")),
+        // User To account check
+        publicKeyX_notZero(pb, accountBefore_To.publicKey.x, FMT(prefix, ".publicKeyX_notZero")),
 
-          balanceF_O_Before(pb, FMT(prefix, "balanceBefore_O")),
+        // Fee as float
+        fFee(pb, constants, Float16Encoding, FMT(prefix, ".fFee")),
+        requireAccuracyFee(pb, fFee.value(), fee.packed, Float16Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyFee")),
+        // Amount as float
+        fAmount(pb, constants, Float24Encoding, FMT(prefix, ".fTansAmount")),
+        requireAccuracyAmount(pb, fAmount.value(), amount.packed, Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyAmount")),
 
-          // Fee payment to the operator
-          fFee(pb, constants, Float16Encoding, FMT(prefix, ".fFee")),
-          ensureAccuracyFee(pb, fFee.value(), fee.packed, Float16Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".ensureAccuracyFee")),
-          feePayment(pb, NUM_BITS_AMOUNT, balanceF_A_Before.balance, balanceF_O_Before.balance, fFee.value(), FMT(prefix, ".feePayment")),
+        // Fee payment from From to the operator
+        feePayment(pb, NUM_BITS_AMOUNT, balanceFBefore_From.balance, balanceBefore_O.balance, fFee.value(), FMT(prefix, ".feePayment")),
+        // Transfer from From to To
+        transferPayment(pb, NUM_BITS_AMOUNT, balanceTBefore_From.balance, balanceTBefore_To.balance, fAmount.value(), FMT(prefix, ".transferPayment")),
 
-          // Calculate how much can be transferred and transfer payment from A to B
-          fTransAmount(pb, constants, Float24Encoding, FMT(prefix, ".fTansAmount")),
-          ensureAccuracyTransAmount(pb, fTransAmount.value(), transAmount.packed, Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".ensureAccuracyTransAmount")),
-          transferPayment(pb, NUM_BITS_AMOUNT, balanceT_A_Before.balance, balanceT_B_Before.balance, fTransAmount.value(), FMT(prefix, ".transferPayment")),
+        // Increase the nonce of From by 1
+        nonce_From_after(pb, accountBefore_From.nonce, constants.one, NUM_BITS_NONCE, FMT(prefix, ".nonce_From_after")),
 
-          // Increase A nonce by 1
-          nonce_A_after(pb, account_A_Before.nonce, constants.one, NUM_BITS_NONCE, FMT(prefix, ".nonce_A_after")),
+        // Update User From
+        updateBalanceF_From(pb, accountBefore_From.balancesRoot, feeTokenID.bits,
+                            {balanceFBefore_From.balance, balanceFBefore_From.tradingHistory},
+                            {feePayment.X, balanceFBefore_From.tradingHistory},
+                            FMT(prefix, ".updateBalanceF_From")),
+        updateBalanceT_From(pb, updateBalanceF_From.result(), tokenID.bits,
+                            {balanceTBefore_From.balance, balanceTBefore_From.tradingHistory},
+                            {transferPayment.X, balanceTBefore_From.tradingHistory},
+                            FMT(prefix, ".updateBalanceT_From")),
+        updateAccount_From(pb, accountsMerkleRoot, accountID_From.bits,
+                           {accountBefore_From.publicKey.x, accountBefore_From.publicKey.y, accountBefore_From.nonce, accountBefore_From.balancesRoot},
+                           {accountBefore_From.publicKey.x, accountBefore_From.publicKey.y, nonce_From_after.result(), updateBalanceT_From.result()},
+                           FMT(prefix, ".updateAccount_From")),
 
-          // Balance
-          updateBalanceF_A(pb, account_A_Before.balancesRoot, feeTokenID.bits,
-                           {balanceF_A_Before.balance, balanceF_A_Before.tradingHistory},
-                           {feePayment.X, balanceF_A_Before.tradingHistory},
-                           FMT(prefix, ".updateBalanceF_A")),
+        // Update User To
+        updateBalanceT_To(pb, accountBefore_To.balancesRoot, tokenID.bits,
+                          {balanceTBefore_To.balance, balanceTBefore_To.tradingHistory},
+                          {transferPayment.Y, balanceTBefore_To.tradingHistory},
+                          FMT(prefix, ".updateBalanceT_To")),
+        updateAccount_To(pb, updateAccount_From.result(), accountID_To.bits,
+                         {accountBefore_To.publicKey.x, accountBefore_To.publicKey.y, accountBefore_To.nonce, accountBefore_To.balancesRoot},
+                         {accountBefore_To.publicKey.x, accountBefore_To.publicKey.y, accountBefore_To.nonce, updateBalanceT_To.result()},
+                         FMT(prefix, ".updateAccount_To")),
 
-          updateBalanceT_A(pb, updateBalanceF_A.result(), transTokenID.bits,
-                           {balanceT_A_Before.balance, balanceT_A_Before.tradingHistory},
-                           {transferPayment.X, balanceT_A_Before.tradingHistory},
-                           FMT(prefix, ".updateBalanceT_A")),
+        // Update Operator
+        updateBalanceF_O(pb, operatorBalancesRoot, feeTokenID.bits,
+                         {balanceBefore_O.balance, balanceBefore_O.tradingHistory},
+                         {feePayment.Y, balanceBefore_O.tradingHistory},
+                         FMT(prefix, ".updateBalanceF_O")),
 
-          updateBalanceT_B(pb, account_B_Before.balancesRoot, transTokenID.bits,
-                           {balanceT_B_Before.balance, balanceT_B_Before.tradingHistory},
-                           {transferPayment.Y, balanceT_B_Before.tradingHistory},
-                           FMT(prefix, ".updateBalanceT_B")),
-
-          // Account
-          updateAccount_A(pb, _accountsMerkleRoot, accountID_A.bits,
-                          {account_A_Before.publicKey.x, account_A_Before.publicKey.y, account_A_Before.nonce, account_A_Before.balancesRoot},
-                          {account_A_Before.publicKey.x, account_A_Before.publicKey.y, nonce_A_after.result(), updateBalanceT_A.result()},
-                          FMT(prefix, ".updateAccount_A")),
-
-          updateAccount_B(pb, updateAccount_A.result(), accountID_B.bits,
-                          {account_B_Before.publicKey.x, account_B_Before.publicKey.y, account_B_Before.nonce, account_B_Before.balancesRoot},
-                          {account_B_Before.publicKey.x, account_B_Before.publicKey.y, account_B_Before.nonce, updateBalanceT_B.result()},
-                          FMT(prefix, ".updateAccount_B")),
-
-          // Operator balance
-          updateBalanceF_O(pb, _operatorBalancesRoot, transTokenID.bits,
-                           {balanceF_O_Before.balance, balanceF_O_Before.tradingHistory},
-                           {feePayment.Y, balanceF_O_Before.tradingHistory},
-                           FMT(prefix, ".updateBalanceF_O")),
-
-          // Signature
-          hash(pb, var_array({blockExchangeID, accountID_A.packed, accountID_B.packed, transTokenID.packed, transAmount.packed, feeTokenID.packed, fee.packed, label, account_A_Before.nonce}), FMT(this->annotation_prefix, ".hash")),
-          signatureVerifier(pb, params, account_A_Before.publicKey, hash.result(), FMT(prefix, ".signatureVerifier")),
-
-          dataPadding_0000(constants.padding_0000)
+        // Signature
+        hash(pb, var_array({blockExchangeID, accountID_From.packed, accountID_To.packed, tokenID.packed, amount.packed, feeTokenID.packed, fee.packed, label, accountBefore_From.nonce}), FMT(this->annotation_prefix, ".hash")),
+        signatureVerifier(pb, params, accountBefore_From.publicKey, hash.result(), FMT(prefix, ".signatureVerifier"))
     {
+
     }
 
-    const VariableT getNewAccountsRoot() const
+    void generate_r1cs_witness(const InternalTransfer& transfer)
     {
-        return updateAccount_B.result();
-    }
+        // User From state
+        balanceFBefore_From.generate_r1cs_witness(transfer.balanceUpdateF_From.before);
+        balanceTBefore_From.generate_r1cs_witness(transfer.balanceUpdateT_From.before);
+        accountBefore_From.generate_r1cs_witness(transfer.accountUpdate_From.before);
+        // User To state
+        balanceTBefore_To.generate_r1cs_witness(transfer.balanceUpdateT_To.before);
+        accountBefore_To.generate_r1cs_witness(transfer.accountUpdate_To.before);
+        // Operator state
+        balanceBefore_O.generate_r1cs_witness(transfer.balanceUpdateF_O.before);
 
-    const VariableT getNewOperatorBalancesRoot() const
-    {
-        return updateBalanceF_O.result();
-    }
+        // Inputs
+        accountID_From.generate_r1cs_witness(pb, transfer.accountUpdate_From.accountID);
+        accountID_To.generate_r1cs_witness(pb, transfer.accountUpdate_To.accountID);
+        tokenID.generate_r1cs_witness(pb, transfer.balanceUpdateT_From.tokenID);
+        amount.generate_r1cs_witness(pb, transfer.amount);
+        feeTokenID.generate_r1cs_witness(pb, transfer.balanceUpdateF_From.tokenID);
+        fee.generate_r1cs_witness(pb, transfer.fee);
+        pb.val(label) = transfer.label;
 
-    const std::vector<VariableArrayT> getPublicData() const
-    {
-        return {
-            accountID_A.bits,
-            accountID_B.bits,
-            transTokenID.bits,
-            fTransAmount.bits(),
-            feeTokenID.bits,
-            fFee.bits()};
-    }
+        // User To account check
+        publicKeyX_notZero.generate_r1cs_witness();
 
-    void generate_r1cs_witness(const InternalTransfer &interTransfer)
-    {
-        accountID_A.generate_r1cs_witness(pb, interTransfer.accountUpdate_A.accountID);
-        accountID_B.generate_r1cs_witness(pb, interTransfer.accountUpdate_B.accountID);
-        feeTokenID.generate_r1cs_witness(pb, interTransfer.balanceUpdateF_A.tokenID);
-        fee.generate_r1cs_witness(pb, interTransfer.fee);
-        transTokenID.generate_r1cs_witness(pb, interTransfer.balanceUpdateT_A.tokenID);
-        transAmount.generate_r1cs_witness(pb, interTransfer.amount);
+        // Fee as float
+        fFee.generate_r1cs_witness(toFloat(transfer.fee, Float16Encoding));
+        requireAccuracyFee.generate_r1cs_witness();
+        // Amount as float
+        fAmount.generate_r1cs_witness(toFloat(transfer.amount, Float24Encoding));
+        requireAccuracyAmount.generate_r1cs_witness();
 
-        pb.val(label) = interTransfer.label;
-
-        balanceF_A_Before.generate_r1cs_witness(interTransfer.balanceUpdateF_A.before); // A pays fee
-        balanceT_A_Before.generate_r1cs_witness(interTransfer.balanceUpdateT_A.before);
-        balanceT_B_Before.generate_r1cs_witness(interTransfer.balanceUpdateT_B.before);
-        account_A_Before.generate_r1cs_witness(interTransfer.accountUpdate_A.before);
-        account_B_Before.generate_r1cs_witness(interTransfer.accountUpdate_B.before);
-
-        balanceF_O_Before.generate_r1cs_witness(interTransfer.balanceUpdateF_O.before);
-
-        // Fee payment calculations
-        fFee.generate_r1cs_witness(toFloat(interTransfer.fee, Float16Encoding));
-        ensureAccuracyFee.generate_r1cs_witness();
+        // Fee payment from From to the operator
         feePayment.generate_r1cs_witness();
-
-        // transfer amount calculation
-        fTransAmount.generate_r1cs_witness(toFloat(interTransfer.amount, Float24Encoding));
-        ensureAccuracyTransAmount.generate_r1cs_witness();
+        // Transfer from From to To
         transferPayment.generate_r1cs_witness();
 
-        // nonce++
-        nonce_A_after.generate_r1cs_witness();
+        // Increase the nonce of From by 1
+        nonce_From_after.generate_r1cs_witness();
 
-        updateBalanceF_A.generate_r1cs_witness(interTransfer.balanceUpdateF_A.proof);
-        updateBalanceT_A.generate_r1cs_witness(interTransfer.balanceUpdateT_A.proof);
-        updateAccount_A.generate_r1cs_witness(interTransfer.accountUpdate_A.proof);
+        // Update User From
+        updateBalanceF_From.generate_r1cs_witness(transfer.balanceUpdateF_From.proof);
+        updateBalanceT_From.generate_r1cs_witness(transfer.balanceUpdateT_From.proof);
+        updateAccount_From.generate_r1cs_witness(transfer.accountUpdate_From.proof);
 
-        updateBalanceT_B.generate_r1cs_witness(interTransfer.balanceUpdateT_B.proof);
-        updateAccount_B.generate_r1cs_witness(interTransfer.accountUpdate_B.proof);
+        // Update User To
+        updateBalanceT_To.generate_r1cs_witness(transfer.balanceUpdateT_To.proof);
+        updateAccount_To.generate_r1cs_witness(transfer.accountUpdate_To.proof);
 
-        updateBalanceF_O.generate_r1cs_witness(interTransfer.balanceUpdateF_O.proof);
+        // Update Operator
+        updateBalanceF_O.generate_r1cs_witness(transfer.balanceUpdateF_O.proof);
 
-        // Check signature
+        // Signature
         hash.generate_r1cs_witness();
-        signatureVerifier.generate_r1cs_witness(interTransfer.signature);
+        signatureVerifier.generate_r1cs_witness(transfer.signature);
     }
 
     void generate_r1cs_constraints()
     {
-        accountID_A.generate_r1cs_constraints(true);
-        accountID_B.generate_r1cs_constraints(true);
-        transTokenID.generate_r1cs_constraints(true);
-        transAmount.generate_r1cs_constraints(true);
+        // Inputs
+        accountID_From.generate_r1cs_constraints(true);
+        accountID_To.generate_r1cs_constraints(true);
+        tokenID.generate_r1cs_constraints(true);
+        amount.generate_r1cs_constraints(true);
         feeTokenID.generate_r1cs_constraints(true);
         fee.generate_r1cs_constraints(true);
+        // label has no limit
 
+        // User To account check
+        publicKeyX_notZero.generate_r1cs_constraints();
+
+        // Fee as float
         fFee.generate_r1cs_constraints();
-        ensureAccuracyFee.generate_r1cs_constraints();
+        requireAccuracyFee.generate_r1cs_constraints();
 
-        fTransAmount.generate_r1cs_constraints();
-        ensureAccuracyTransAmount.generate_r1cs_constraints();
+        // Amount as float
+        fAmount.generate_r1cs_constraints();
+        requireAccuracyAmount.generate_r1cs_constraints();
 
-        nonce_A_after.generate_r1cs_constraints();
-
-        // Fee payment calculations
+        // Fee payment from From to the operator
         feePayment.generate_r1cs_constraints();
+        // Transfer from From to To
         transferPayment.generate_r1cs_constraints();
 
-        // Account
-        updateBalanceF_A.generate_r1cs_constraints();
-        updateBalanceT_A.generate_r1cs_constraints();
-        updateAccount_A.generate_r1cs_constraints();
+        // Increase the nonce of From by 1
+        nonce_From_after.generate_r1cs_constraints();
 
-        updateBalanceT_B.generate_r1cs_constraints();
-        updateAccount_B.generate_r1cs_constraints();
+        // Update User From
+        updateBalanceF_From.generate_r1cs_constraints();
+        updateBalanceT_From.generate_r1cs_constraints();
+        updateAccount_From.generate_r1cs_constraints();
 
-        // Operator
+        // Update User To
+        updateBalanceT_To.generate_r1cs_constraints();
+        updateAccount_To.generate_r1cs_constraints();
+
+        // Update Operator
         updateBalanceF_O.generate_r1cs_constraints();
 
-        // Check signature
+        // Signature
         hash.generate_r1cs_constraints();
         signatureVerifier.generate_r1cs_constraints();
+    }
+
+    const std::vector<VariableArrayT> getPublicData() const
+    {
+        return {accountID_From.bits,
+                accountID_To.bits,
+                tokenID.bits,
+                fAmount.bits(),
+                feeTokenID.bits,
+                fFee.bits()};
+    }
+
+    const VariableT& getNewAccountsRoot() const
+    {
+        return updateAccount_To.result();
+    }
+
+    const VariableT& getNewOperatorBalancesRoot() const
+    {
+        return updateBalanceF_O.result();
     }
 };
 
@@ -255,9 +284,7 @@ class InternalTransferCircuit : public GadgetT
 {
 public:
     PublicDataGadget publicData;
-
     Constants constants;
-
     jubjub::Params params;
 
     // State
@@ -269,14 +296,18 @@ public:
     DualVariableGadget merkleRootAfter;
     DualVariableGadget operatorAccountID;
 
+    // Operator account check
     RequireNotZeroGadget publicKeyX_notZero;
 
+    // Internal transfers
     bool onchainDataAvailability;
-    unsigned int numTrans;
-    std::vector<InternalTransferGadget> interTransferres;
+    unsigned int numTransfers;
+    std::vector<InternalTransferGadget> transfers;
 
+    // Update Operator
     std::unique_ptr<UpdateAccountGadget> updateAccount_O;
 
+    // Labels
     std::vector<VariableT> labels;
     std::unique_ptr<LabelHasher> labelHasher;
 
@@ -284,7 +315,6 @@ public:
         : GadgetT(pb, prefix),
 
           publicData(pb, FMT(prefix, ".publicData")),
-
           constants(pb, FMT(prefix, ".constants")),
 
           // State
@@ -296,25 +326,34 @@ public:
           merkleRootAfter(pb, 256, FMT(prefix, ".merkleRootAfter")),
           operatorAccountID(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".operatorAccountID")),
 
+          // Operator account check
           publicKeyX_notZero(pb, accountBefore_O.publicKey.x, FMT(prefix, ".publicKeyX_notZero"))
     {
     }
 
-    void generate_r1cs_constraints(bool onchainDataAvailability, int numTrans)
+    void generate_r1cs_constraints(bool onchainDataAvailability, int numTransfers)
     {
         this->onchainDataAvailability = onchainDataAvailability;
-        this->numTrans = numTrans;
+        this->numTransfers = numTransfers;
 
         constants.generate_r1cs_constraints();
 
+        // Inputs
+        exchangeID.generate_r1cs_constraints(true);
+        merkleRootBefore.generate_r1cs_constraints(true);
+        merkleRootAfter.generate_r1cs_constraints(true);
+        operatorAccountID.generate_r1cs_constraints(true);
+
+        // Operator account check
         publicKeyX_notZero.generate_r1cs_constraints();
 
-        for (size_t j = 0; j < numTrans; j++)
+        // Internal transfers
+        for (size_t j = 0; j < numTransfers; j++)
         {
-            VariableT transAccountsRoot = (j == 0) ? merkleRootBefore.packed : interTransferres.back().getNewAccountsRoot();
-            VariableT transOperatorBalancesRoot = (j == 0) ? accountBefore_O.balancesRoot : interTransferres.back().getNewOperatorBalancesRoot();
+            VariableT transAccountsRoot = (j == 0) ? merkleRootBefore.packed : transfers.back().getNewAccountsRoot();
+            VariableT transOperatorBalancesRoot = (j == 0) ? accountBefore_O.balancesRoot : transfers.back().getNewOperatorBalancesRoot();
 
-            interTransferres.emplace_back(
+            transfers.emplace_back(
                 pb,
                 params,
                 constants,
@@ -322,19 +361,18 @@ public:
                 transOperatorBalancesRoot,
                 exchangeID.packed,
                 std::string("transfer_") + std::to_string(j));
-            interTransferres.back().generate_r1cs_constraints();
-            labels.push_back(interTransferres.back().label);
+            transfers.back().generate_r1cs_constraints();
+            labels.push_back(transfers.back().label);
         }
 
-        // Update operator account
-        operatorAccountID.generate_r1cs_constraints(true);
-        updateAccount_O.reset(new UpdateAccountGadget(pb, interTransferres.back().getNewAccountsRoot(), operatorAccountID.bits,
-                                                      {accountBefore_O.publicKey.x, accountBefore_O.publicKey.y, accountBefore_O.nonce, accountBefore_O.balancesRoot},
-                                                      {accountBefore_O.publicKey.x, accountBefore_O.publicKey.y, accountBefore_O.nonce, interTransferres.back().getNewOperatorBalancesRoot()},
-                                                      FMT(annotation_prefix, ".updateAccount_O")));
+        // Update Operator
+        updateAccount_O.reset(new UpdateAccountGadget(pb, transfers.back().getNewAccountsRoot(), operatorAccountID.bits,
+            {accountBefore_O.publicKey.x, accountBefore_O.publicKey.y, accountBefore_O.nonce, accountBefore_O.balancesRoot},
+            {accountBefore_O.publicKey.x, accountBefore_O.publicKey.y, accountBefore_O.nonce, transfers.back().getNewOperatorBalancesRoot()},
+            FMT(annotation_prefix, ".updateAccount_O")));
         updateAccount_O->generate_r1cs_constraints();
 
-        // Calculate the label hash
+        // Labels
         labelHasher.reset(new LabelHasher(pb, constants, labels, FMT(annotation_prefix, ".labelHash")));
         labelHasher->generate_r1cs_constraints();
 
@@ -343,27 +381,19 @@ public:
         publicData.add(merkleRootBefore.bits);
         publicData.add(merkleRootAfter.bits);
         publicData.add(labelHasher->result()->bits);
-
         if (onchainDataAvailability)
         {
             publicData.add(constants.padding_0000);
             publicData.add(operatorAccountID.bits);
-            for (const InternalTransferGadget &trans : interTransferres)
+            for (const InternalTransferGadget& transfer : transfers)
             {
-                publicData.add(trans.getPublicData());
+                publicData.add(transfer.getPublicData());
             }
         }
-
-        // Check the input hash
         publicData.generate_r1cs_constraints();
 
         // Check the new merkle root
         requireEqual(pb, updateAccount_O->result(), merkleRootAfter.packed, "newMerkleRoot");
-    }
-
-    void printInfo()
-    {
-        std::cout << pb.num_constraints() << " constraints (" << (pb.num_constraints() / numTrans) << "/transfer)" << std::endl;
     }
 
     bool generateWitness(const Loopring::InternalTransferBlock &block)
@@ -373,32 +403,36 @@ public:
         // State
         accountBefore_O.generate_r1cs_witness(block.accountUpdate_O.before);
 
-        exchangeID.bits.fill_with_bits_of_field_element(pb, block.exchangeID);
-        exchangeID.generate_r1cs_witness_from_bits();
+        // Inputs
+        exchangeID.generate_r1cs_witness(pb, block.exchangeID);
+        merkleRootBefore.generate_r1cs_witness(pb, block.merkleRootBefore);
+        merkleRootAfter.generate_r1cs_witness(pb, block.merkleRootAfter);
+        operatorAccountID.generate_r1cs_witness(pb, block.operatorAccountID);
 
-        merkleRootBefore.bits.fill_with_bits_of_field_element(pb, block.merkleRootBefore);
-        merkleRootBefore.generate_r1cs_witness_from_bits();
-        merkleRootAfter.bits.fill_with_bits_of_field_element(pb, block.merkleRootAfter);
-        merkleRootAfter.generate_r1cs_witness_from_bits();
-
-        operatorAccountID.bits.fill_with_bits_of_field_element(pb, block.operatorAccountID);
-        operatorAccountID.generate_r1cs_witness_from_bits();
-
+        // Operator account check
         publicKeyX_notZero.generate_r1cs_witness();
 
-        for (unsigned int i = 0; i < block.interTransferres.size(); i++)
+        // Internal transfers
+        for (unsigned int i = 0; i < block.transfers.size(); i++)
         {
-            interTransferres[i].generate_r1cs_witness(block.interTransferres[i]);
+            transfers[i].generate_r1cs_witness(block.transfers[i]);
         }
 
+        // Update operator
         updateAccount_O->generate_r1cs_witness(block.accountUpdate_O.proof);
 
-        // Calculate the label hash
+        // Labels
         labelHasher->generate_r1cs_witness();
 
+        // Public data
         publicData.generate_r1cs_witness();
 
         return true;
+    }
+
+    void printInfo()
+    {
+        std::cout << pb.num_constraints() << " constraints (" << (pb.num_constraints() / numTransfers) << "/transfer)" << std::endl;
     }
 };
 

--- a/Utils/Data.h
+++ b/Utils/Data.h
@@ -558,14 +558,14 @@ public:
     ethsnarks::FieldT label;
     Signature signature;
 
-    BalanceUpdate balanceUpdateF_A; // pay fee step
-    BalanceUpdate balanceUpdateT_A; // trans step
-    AccountUpdate accountUpdate_A;
+    BalanceUpdate balanceUpdateF_From; // pay fee step
+    BalanceUpdate balanceUpdateT_From; // transfer step
+    AccountUpdate accountUpdate_From;
 
-    BalanceUpdate balanceUpdateT_B;	// recieve trans
-    AccountUpdate accountUpdate_B;
-        
-    BalanceUpdate balanceUpdateF_O;	// recieve fee
+    BalanceUpdate balanceUpdateT_To;   // receive transfer
+    AccountUpdate accountUpdate_To;
+
+    BalanceUpdate balanceUpdateF_O;	   // receive fee
 };
 
 static void from_json(const json& j, InternalTransfer& interTrans)
@@ -575,12 +575,12 @@ static void from_json(const json& j, InternalTransfer& interTrans)
     interTrans.label = ethsnarks::FieldT(j.at("label"));
     interTrans.signature = j.at("signature").get<Signature>();
 
-    interTrans.balanceUpdateF_A = j.at("balanceUpdateF_From").get<BalanceUpdate>();
-    interTrans.balanceUpdateT_A = j.at("balanceUpdateT_From").get<BalanceUpdate>();
-    interTrans.accountUpdate_A = j.at("accountUpdate_From").get<AccountUpdate>();
+    interTrans.balanceUpdateF_From = j.at("balanceUpdateF_From").get<BalanceUpdate>();
+    interTrans.balanceUpdateT_From = j.at("balanceUpdateT_From").get<BalanceUpdate>();
+    interTrans.accountUpdate_From = j.at("accountUpdate_From").get<AccountUpdate>();
 
-    interTrans.balanceUpdateT_B = j.at("balanceUpdateT_To").get<BalanceUpdate>();
-    interTrans.accountUpdate_B = j.at("accountUpdate_To").get<AccountUpdate>();
+    interTrans.balanceUpdateT_To = j.at("balanceUpdateT_To").get<BalanceUpdate>();
+    interTrans.accountUpdate_To = j.at("accountUpdate_To").get<AccountUpdate>();
 
     interTrans.balanceUpdateF_O = j.at("balanceUpdateF_O").get<BalanceUpdate>();
 }
@@ -596,7 +596,7 @@ public:
     ethsnarks::FieldT operatorAccountID;
     AccountUpdate accountUpdate_O;
 
-    std::vector<Loopring::InternalTransfer> interTransferres;
+    std::vector<Loopring::InternalTransfer> transfers;
 };
 
 static void from_json(const json& j, InternalTransferBlock& block)
@@ -609,11 +609,11 @@ static void from_json(const json& j, InternalTransferBlock& block)
     block.operatorAccountID = ethsnarks::FieldT(j.at("operatorAccountID"));
     block.accountUpdate_O = j.at("accountUpdate_O").get<AccountUpdate>();
 
-    // Read internal transferres
-    json jInterTranferres = j["internalTransferres"];
-    for(unsigned int i = 0; i < jInterTranferres.size(); i++)
+    // Read internal transfers
+    json jTransfers = j["transfers"];
+    for(unsigned int i = 0; i < jTransfers.size(); i++)
     {
-        block.interTransferres.emplace_back(jInterTranferres[i].get<Loopring::InternalTransfer>());
+        block.transfers.emplace_back(jTransfers[i].get<Loopring::InternalTransfer>());
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -226,19 +226,19 @@ bool cancel(Mode mode, bool onchainDataAvailability, unsigned int numCancels, co
     return true;
 }
 
-bool internalTransfer(Mode mode, bool onchainDataAvailability, unsigned int numTrans, const json& input, ethsnarks::ProtoboardT& outPb)
+bool internalTransfer(Mode mode, bool onchainDataAvailability, unsigned int numTransfers, const json& input, ethsnarks::ProtoboardT& outPb)
 {
     // Build the circuit
     Loopring::InternalTransferCircuit circuit(outPb, "circuit");
-    circuit.generate_r1cs_constraints(onchainDataAvailability, numTrans);
+    circuit.generate_r1cs_constraints(onchainDataAvailability, numTransfers);
     circuit.printInfo();
 
     if (mode == Mode::Validate || mode == Mode::Prove)
     {
-        json jTransferres = input["internalTransferres"];
-        if (jTransferres.size() != numTrans)
+        json jTransfers = input["transfers"];
+        if (jTransfers.size() != numTransfers)
         {
-            std::cerr << "Invalid number of cancels in input file: " << jTransferres.size() << std::endl;
+            std::cerr << "Invalid number of transfers in input file: " << jTransfers.size() << std::endl;
             return false;
         }
 


### PR DESCRIPTION
Add internal transfer ciruit to enable internal transfer.
The basic design is pretty much like off-chain withdraw, except
the balance change in receiver account.

Basic Design:
1. Account A transfers value to account B and pays fee to Operator O.
2. The fee token can be different from transfer token as other requests.
3. Account A's nonce++, account B does not.
4. No trading history change.

WIP:
1. Circuit verification.
2. Exchange test cases.
3. Contract block support.