### PR TITLE
[Draft] Use fillS_A/B of ring info offered by Relay to calculate the matching result.

### DIFF
--- a/Circuits/RingSettlementCircuit.h
+++ b/Circuits/RingSettlementCircuit.h
@@ -212,14 +212,16 @@ public:
         tradingHistoryRootA_O(make_variable(pb, FMT(prefix, ".tradingHistoryRootA_O"))),
         tradingHistoryRootB_O(make_variable(pb, FMT(prefix, ".tradingHistoryRootB_O"))),
 
+        // Max tradable balance
+        fillS_A(pb, constants, Float24Encoding, FMT(prefix, ".fillS_A")),
+        fillS_B(pb, constants, Float24Encoding, FMT(prefix, ".fillS_B")),
+
         // Match orders
-        orderMatching(pb, constants, timestamp, orderA, orderB, FMT(prefix, ".orderMatching")),
+        orderMatching(pb, constants, timestamp, orderA, orderB, fillS_A, fillS_B, FMT(prefix, ".orderMatching")),
 
         // Fill amounts
         uFillS_A(pb, orderMatching.isValid(), orderMatching.getFillA_S(), constants.zero, FMT(prefix, ".uFillS_A")),
         uFillS_B(pb, orderMatching.isValid(), orderMatching.getFillB_S(), constants.zero, FMT(prefix, ".uFillS_B")),
-        fillS_A(pb, constants, Float24Encoding, FMT(prefix, ".fillS_A")),
-        fillS_B(pb, constants, Float24Encoding, FMT(prefix, ".fillS_B")),
         requireAccuracyFillS_A(pb, fillS_A.value(), uFillS_A.result(), Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyFillS_A")),
         requireAccuracyFillS_B(pb, fillS_B.value(), uFillS_B.result(), Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyFillS_B")),
 
@@ -335,8 +337,8 @@ public:
         // Fill amounts
         uFillS_A.generate_r1cs_witness();
         uFillS_B.generate_r1cs_witness();
-        fillS_A.generate_r1cs_witness(toFloat(pb.val(uFillS_A.result()), Float24Encoding));
-        fillS_B.generate_r1cs_witness(toFloat(pb.val(uFillS_B.result()), Float24Encoding));
+        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
+        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
         requireAccuracyFillS_A.generate_r1cs_witness();
         requireAccuracyFillS_B.generate_r1cs_witness();
 

--- a/Circuits/RingSettlementCircuit.h
+++ b/Circuits/RingSettlementCircuit.h
@@ -124,14 +124,16 @@ public:
     const VariableT tradingHistoryRootA_O;
     const VariableT tradingHistoryRootB_O;
 
+    // input Fill amounts
+    FloatGadget fillS_A;
+    FloatGadget fillS_B;
+
     // Match orders
     OrderMatchingGadget orderMatching;
 
     // Fill amounts
     TernaryGadget uFillS_A;
     TernaryGadget uFillS_B;
-    FloatGadget fillS_A;
-    FloatGadget fillS_B;
     RequireAccuracyGadget requireAccuracyFillS_A;
     RequireAccuracyGadget requireAccuracyFillS_B;
 
@@ -331,14 +333,17 @@ public:
         pb.val(tradingHistoryRootA_O) = ringSettlement.balanceUpdateA_O.before.tradingHistoryRoot;
         pb.val(tradingHistoryRootB_O) = ringSettlement.balanceUpdateB_O.before.tradingHistoryRoot;
 
+        // input fillS_A/B
+        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
+        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
+
         // Match orders
         orderMatching.generate_r1cs_witness();
 
         // Fill amounts
         uFillS_A.generate_r1cs_witness();
         uFillS_B.generate_r1cs_witness();
-        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
-        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
+
         requireAccuracyFillS_A.generate_r1cs_witness();
         requireAccuracyFillS_B.generate_r1cs_witness();
 
@@ -394,14 +399,16 @@ public:
         orderA.generate_r1cs_constraints();
         orderB.generate_r1cs_constraints();
 
+        // input fillS_A/B
+        fillS_A.generate_r1cs_constraints();
+        fillS_B.generate_r1cs_constraints();
+
         // Match orders
         orderMatching.generate_r1cs_constraints();
 
         // Fill amounts
         uFillS_A.generate_r1cs_constraints();
         uFillS_B.generate_r1cs_constraints();
-        fillS_A.generate_r1cs_constraints();
-        fillS_B.generate_r1cs_constraints();
         requireAccuracyFillS_A.generate_r1cs_constraints();
         requireAccuracyFillS_B.generate_r1cs_constraints();
 

--- a/Gadgets/MatchingGadgets.h
+++ b/Gadgets/MatchingGadgets.h
@@ -390,7 +390,7 @@ public:
     ) :
         GadgetT(pb, prefix),
 
-        takerFillB_lt_makerFillS(pb, takerFill.B, makerFill.S, NUM_BITS_AMOUNT, FMT(prefix, ".takerFill.B < makerFill.B")),
+        takerFillB_lt_makerFillS(pb, takerFill.B, makerFill.S, NUM_BITS_AMOUNT, FMT(prefix, ".takerFill.B < makerFill.S")),
 
         // Do a single MulDiv for both case:
         // - if takerFill.B < makerFill.S: takerFill.B * makerOrder.amountB // makerOrder.amountS

--- a/Utils/Data.h
+++ b/Utils/Data.h
@@ -210,12 +210,16 @@ class Ring
 public:
     Order orderA;
     Order orderB;
+    ethsnarks::FieldT fillS_A;
+    ethsnarks::FieldT fillS_B;
 };
 
 static void from_json(const json& j, Ring& ring)
 {
     ring.orderA = j.at("orderA").get<Order>();
     ring.orderB = j.at("orderB").get<Order>();
+    ring.fillS_A = ethsnarks::FieldT(j["fFillS_A"]);
+    ring.fillS_B = ethsnarks::FieldT(j["fFillS_B"]);
 }
 
 class RingSettlement

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -156,6 +156,12 @@ static BigInt fromFloat(unsigned int f, const FloatEncoding& encoding)
     return value;
 }
 
+static FieldT roundToFloatValue(const FieldT& value, const FloatEncoding& encoding) {
+  auto f = toFloat(value, encoding);
+  auto floatValue = fromFloat(f, encoding);
+  return FieldT(floatValue.to_string().c_str());
+}
+
 }
 
 #endif


### PR DESCRIPTION
Draft PR for #23.

Basic idea is to use FillS_A/B offered by Relay. Instead of order match calculation based on them, I just check the data validity and consequently the order match validity.
It turns out now order matching gadget relies on fill rate checking only, if it's ok, perhaps in the future, we can use these 2 value alone and skip the complex order matching logic in the circuit. 