### PR TITLE
Flexible/Less complex order matching

### DIFF
--- a/Circuits/RingSettlementCircuit.h
+++ b/Circuits/RingSettlementCircuit.h
@@ -212,14 +212,16 @@ public:
         tradingHistoryRootA_O(make_variable(pb, FMT(prefix, ".tradingHistoryRootA_O"))),
         tradingHistoryRootB_O(make_variable(pb, FMT(prefix, ".tradingHistoryRootB_O"))),
 
+        // Max tradable balance
+        fillS_A(pb, constants, Float24Encoding, FMT(prefix, ".fillS_A")),
+        fillS_B(pb, constants, Float24Encoding, FMT(prefix, ".fillS_B")),
+
         // Match orders
-        orderMatching(pb, constants, timestamp, orderA, orderB, FMT(prefix, ".orderMatching")),
+        orderMatching(pb, constants, timestamp, orderA, orderB, fillS_A, fillS_B, FMT(prefix, ".orderMatching")),
 
         // Fill amounts
         uFillS_A(pb, orderMatching.isValid(), orderMatching.getFillA_S(), constants.zero, FMT(prefix, ".uFillS_A")),
         uFillS_B(pb, orderMatching.isValid(), orderMatching.getFillB_S(), constants.zero, FMT(prefix, ".uFillS_B")),
-        fillS_A(pb, constants, Float24Encoding, FMT(prefix, ".fillS_A")),
-        fillS_B(pb, constants, Float24Encoding, FMT(prefix, ".fillS_B")),
         requireAccuracyFillS_A(pb, fillS_A.value(), uFillS_A.result(), Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyFillS_A")),
         requireAccuracyFillS_B(pb, fillS_B.value(), uFillS_B.result(), Float24Accuracy, NUM_BITS_AMOUNT, FMT(prefix, ".requireAccuracyFillS_B")),
 
@@ -335,8 +337,8 @@ public:
         // Fill amounts
         uFillS_A.generate_r1cs_witness();
         uFillS_B.generate_r1cs_witness();
-        fillS_A.generate_r1cs_witness(toFloat(pb.val(uFillS_A.result()), Float24Encoding));
-        fillS_B.generate_r1cs_witness(toFloat(pb.val(uFillS_B.result()), Float24Encoding));
+        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
+        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
         requireAccuracyFillS_A.generate_r1cs_witness();
         requireAccuracyFillS_B.generate_r1cs_witness();
 

--- a/Circuits/RingSettlementCircuit.h
+++ b/Circuits/RingSettlementCircuit.h
@@ -124,14 +124,16 @@ public:
     const VariableT tradingHistoryRootA_O;
     const VariableT tradingHistoryRootB_O;
 
+    // input Fill amounts
+    FloatGadget fillS_A;
+    FloatGadget fillS_B;
+
     // Match orders
     OrderMatchingGadget orderMatching;
 
     // Fill amounts
     TernaryGadget uFillS_A;
     TernaryGadget uFillS_B;
-    FloatGadget fillS_A;
-    FloatGadget fillS_B;
     RequireAccuracyGadget requireAccuracyFillS_A;
     RequireAccuracyGadget requireAccuracyFillS_B;
 
@@ -331,14 +333,17 @@ public:
         pb.val(tradingHistoryRootA_O) = ringSettlement.balanceUpdateA_O.before.tradingHistoryRoot;
         pb.val(tradingHistoryRootB_O) = ringSettlement.balanceUpdateB_O.before.tradingHistoryRoot;
 
+        // input fillS_A/B
+        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
+        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
+
         // Match orders
         orderMatching.generate_r1cs_witness();
 
         // Fill amounts
         uFillS_A.generate_r1cs_witness();
         uFillS_B.generate_r1cs_witness();
-        fillS_A.generate_r1cs_witness(ringSettlement.ring.fillS_A);
-        fillS_B.generate_r1cs_witness(ringSettlement.ring.fillS_B);
+
         requireAccuracyFillS_A.generate_r1cs_witness();
         requireAccuracyFillS_B.generate_r1cs_witness();
 
@@ -394,14 +399,16 @@ public:
         orderA.generate_r1cs_constraints();
         orderB.generate_r1cs_constraints();
 
+        // input fillS_A/B
+        fillS_A.generate_r1cs_constraints();
+        fillS_B.generate_r1cs_constraints();
+
         // Match orders
         orderMatching.generate_r1cs_constraints();
 
         // Fill amounts
         uFillS_A.generate_r1cs_constraints();
         uFillS_B.generate_r1cs_constraints();
-        fillS_A.generate_r1cs_constraints();
-        fillS_B.generate_r1cs_constraints();
         requireAccuracyFillS_A.generate_r1cs_constraints();
         requireAccuracyFillS_B.generate_r1cs_constraints();
 

--- a/Gadgets/MatchingGadgets.h
+++ b/Gadgets/MatchingGadgets.h
@@ -16,21 +16,21 @@ using namespace ethsnarks;
 namespace Loopring
 {
 
-// Checks if the fill rate < 1% worse than the target rate
-// (fillAmountS/fillAmountB) * 100 < (amountS/amountB) * 101
-// (fillAmountS * amountB * 100) < (fillAmountB * amountS * 101)
-class CheckFillRateGadget : public GadgetT
+// Checks if the fill rate < 0.1% worse than the target rate
+// (fillAmountS/fillAmountB) * 1000 < (amountS/amountB) * 1001
+// (fillAmountS * amountB * 1000) < (fillAmountB * amountS * 1001)
+class RequireFillRateGadget : public GadgetT
 {
 public:
     UnsafeMulGadget fillAmountS_mul_amountB;
-    UnsafeMulGadget fillAmountS_mul_amountB_mul_100;
+    UnsafeMulGadget fillAmountS_mul_amountB_mul_1000;
 
     UnsafeMulGadget fillAmountB_mul_amountS;
-    UnsafeMulGadget fillAmountB_mul_amountS_mul_101;
+    UnsafeMulGadget fillAmountB_mul_amountS_mul_1001;
 
-    LeqGadget valid;
+    RequireLtGadget valid;
 
-    CheckFillRateGadget(
+    RequireFillRateGadget(
         ProtoboardT& pb,
         const Constants& constants,
         const VariableT& amountS,
@@ -43,12 +43,12 @@ public:
         GadgetT(pb, prefix),
 
         fillAmountS_mul_amountB(pb, fillAmountS, amountB, FMT(prefix, ".fillAmountS_mul_amountB")),
-        fillAmountS_mul_amountB_mul_100(pb, fillAmountS_mul_amountB.result(), constants._100, FMT(prefix, ".fillAmountS_mul_amountB_mul_100")),
+        fillAmountS_mul_amountB_mul_1000(pb, fillAmountS_mul_amountB.result(), constants._1000, FMT(prefix, ".fillAmountS_mul_amountB_mul_1000")),
 
         fillAmountB_mul_amountS(pb, fillAmountB, amountS, FMT(prefix, ".fillAmountB_mul_amountS")),
-        fillAmountB_mul_amountS_mul_101(pb, fillAmountB_mul_amountS.result(), constants._101, FMT(prefix, ".fillAmountB_mul_amountS_mul_101")),
+        fillAmountB_mul_amountS_mul_1001(pb, fillAmountB_mul_amountS.result(), constants._1001, FMT(prefix, ".fillAmountB_mul_amountS_mul_1001")),
 
-        valid(pb, fillAmountS_mul_amountB_mul_100.result(), fillAmountB_mul_amountS_mul_101.result(), n * 2 + 7 /*=ceil(log2(100))*/, FMT(prefix, ".valid"))
+        valid(pb, fillAmountS_mul_amountB_mul_1000.result(), fillAmountB_mul_amountS_mul_1001.result(), n * 2 + 10 /*=ceil(log2(1000))*/, FMT(prefix, ".valid"))
     {
 
     }
@@ -56,10 +56,10 @@ public:
     void generate_r1cs_witness()
     {
         fillAmountS_mul_amountB.generate_r1cs_witness();
-        fillAmountS_mul_amountB_mul_100.generate_r1cs_witness();
+        fillAmountS_mul_amountB_mul_1000.generate_r1cs_witness();
 
         fillAmountB_mul_amountS.generate_r1cs_witness();
-        fillAmountB_mul_amountS_mul_101.generate_r1cs_witness();
+        fillAmountB_mul_amountS_mul_1001.generate_r1cs_witness();
 
         valid.generate_r1cs_witness();
     }
@@ -67,17 +67,12 @@ public:
     void generate_r1cs_constraints()
     {
         fillAmountS_mul_amountB.generate_r1cs_constraints();
-        fillAmountS_mul_amountB_mul_100.generate_r1cs_constraints();
+        fillAmountS_mul_amountB_mul_1000.generate_r1cs_constraints();
 
         fillAmountB_mul_amountS.generate_r1cs_constraints();
-        fillAmountB_mul_amountS_mul_101.generate_r1cs_constraints();
+        fillAmountB_mul_amountS_mul_1001.generate_r1cs_constraints();
 
         valid.generate_r1cs_constraints();
-    }
-
-    const VariableT& isValid() const
-    {
-        return valid.lt();
     }
 };
 
@@ -94,8 +89,6 @@ public:
 
     LeqGadget validSince_leq_timestamp;
     LeqGadget timestamp_leq_validUntil;
-
-    CheckFillRateGadget checkFillRate;
 
     NotGadget validAllOrNoneSell;
     NotGadget validAllOrNoneBuy;
@@ -129,8 +122,6 @@ public:
         validAllOrNoneSell(pb, notValidAllOrNoneSell.result(), FMT(prefix, "validAllOrNoneSell")),
         validAllOrNoneBuy(pb, notValidAllOrNoneBuy.result(), FMT(prefix, "validAllOrNoneBuy")),
 
-        checkFillRate(pb, constants, order.amountS.packed, order.amountB.packed, fillAmountS, fillAmountB, NUM_BITS_AMOUNT, FMT(prefix, ".checkFillRate")),
-
         // This is an important check that makes sure no token transfers can happen to unregistered token IDs
         isNonZeroFillAmountS(pb, fillAmountS, FMT(prefix, "isNonZeroFillAmountS")),
         isNonZeroFillAmountB(pb, fillAmountB, FMT(prefix, "isNonZeroFillAmountB")),
@@ -139,7 +130,6 @@ public:
                 {
                     validSince_leq_timestamp.leq(),
                     timestamp_leq_validUntil.leq(),
-                    checkFillRate.isValid(),
                     validAllOrNoneSell.result(),
                     validAllOrNoneBuy.result(),
                     isNonZeroFillAmountS.result(),
@@ -165,8 +155,6 @@ public:
         validAllOrNoneSell.generate_r1cs_witness();
         validAllOrNoneBuy.generate_r1cs_witness();
 
-        checkFillRate.generate_r1cs_witness();
-
         isNonZeroFillAmountS.generate_r1cs_witness();
         isNonZeroFillAmountB.generate_r1cs_witness();
 
@@ -186,8 +174,6 @@ public:
 
         validAllOrNoneSell.generate_r1cs_constraints();
         validAllOrNoneBuy.generate_r1cs_constraints();
-
-        checkFillRate.generate_r1cs_constraints();
 
         isNonZeroFillAmountS.generate_r1cs_constraints();
         isNonZeroFillAmountB.generate_r1cs_constraints();
@@ -260,415 +246,107 @@ public:
     }
 };
 
-// Calculate the max fill amounts of the order
-class MaxFillAmountsGadget : public GadgetT
+// Checks if the order isn't filled too much
+class RequireFillLimitGadget : public GadgetT
 {
 public:
-    TernaryGadget limit;
-    MinGadget filledLimited;
-    UnsafeSubGadget remainingBeforeCancelled;
-    TernaryGadget remaining;
-    MulDivGadget remainingS_buy;
-    TernaryGadget remainingS;
-    MinGadget fillAmountS;
-    MulDivGadget fillAmountB;
+    TernaryGadget fillAmount;
+    TernaryGadget fillLimitBeforeCancelled;
+    TernaryGadget fillLimit;
+    AddGadget filledAfter;
+    RequireLeqGadget filledAfter_leq_fillLimit;
 
-    MaxFillAmountsGadget(
+    RequireFillLimitGadget(
         ProtoboardT& pb,
         const Constants& constants,
         const OrderGadget& order,
+        const VariableT& fillS,
+        const VariableT& fillB,
         const std::string& prefix
     ) :
         GadgetT(pb, prefix),
 
-        // All results here are guaranteed to fit in NUM_BITS_AMOUNT bits
-        // `remainingS_buy = remaining * order.amountS // order.amountB`
-        // `remainingS_buy` has a maximum value of order.amountB, so needs NUM_BITS_AMOUNT max.
-        // `fillAmountB = fillAmountS * order.amountB // order.amountS`
-        // `fillAmountS` has a maximum value of order.amountS, so needs NUM_BITS_AMOUNT max.
-
-        limit(pb, order.buy.packed, order.amountB.packed, order.amountS.packed, FMT(prefix, ".limit")),
-        filledLimited(pb, limit.result(), order.tradeHistory.getFilled(), NUM_BITS_AMOUNT, FMT(prefix, ".filledLimited")),
-        remainingBeforeCancelled(pb, limit.result(), filledLimited.result(), FMT(prefix, ".remainingBeforeCancelled")),
-        remaining(pb, order.tradeHistory.getCancelled(), constants.zero, remainingBeforeCancelled.result(), FMT(prefix, ".remaining")),
-        remainingS_buy(pb, constants, remaining.result(), order.amountS.packed, order.amountB.packed, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, FMT(prefix, ".remainingS_buy")),
-        remainingS(pb, order.buy.packed, remainingS_buy.result(), remaining.result(), FMT(prefix, ".remainingS")),
-        fillAmountS(pb, order.balanceSBefore.balance, remainingS.result(), NUM_BITS_AMOUNT, FMT(prefix, ".fillAmountS")),
-        fillAmountB(pb, constants, fillAmountS.result(), order.amountB.packed, order.amountS.packed, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, FMT(prefix, ".fillAmountB"))
+        fillAmount(pb, order.buy.packed, fillB, fillS, FMT(prefix, ".fillAmount")),
+        fillLimitBeforeCancelled(pb, order.buy.packed, order.amountB.packed, order.amountS.packed, FMT(prefix, ".fillLimitBeforeCancelled")),
+        fillLimit(pb, order.tradeHistory.getCancelled(), order.tradeHistory.getFilled(), fillLimitBeforeCancelled.result(), FMT(prefix, ".fillLimitBeforeCancelled")),
+        filledAfter(pb, order.tradeHistory.getFilled(), fillAmount.result(), NUM_BITS_AMOUNT, FMT(prefix, ".filledAfter")),
+        filledAfter_leq_fillLimit(pb, filledAfter.result(), fillLimit.result(), NUM_BITS_AMOUNT, FMT(prefix, ".filledAfter_leq_fillLimit"))
     {
 
     }
 
     void generate_r1cs_witness()
     {
-        limit.generate_r1cs_witness();
-        filledLimited.generate_r1cs_witness();
-        remainingBeforeCancelled.generate_r1cs_witness();
-        remaining.generate_r1cs_witness();
-        remainingS_buy.generate_r1cs_witness();
-        remainingS.generate_r1cs_witness();
-        fillAmountS.generate_r1cs_witness();
-        fillAmountB.generate_r1cs_witness();
+        fillAmount.generate_r1cs_witness();
+        fillLimitBeforeCancelled.generate_r1cs_witness();
+        fillLimit.generate_r1cs_witness();
+        filledAfter.generate_r1cs_witness();
+        filledAfter_leq_fillLimit.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
     {
-        limit.generate_r1cs_constraints();
-        filledLimited.generate_r1cs_constraints();
-        remainingBeforeCancelled.generate_r1cs_constraints();
-        remaining.generate_r1cs_constraints();
-        remainingS_buy.generate_r1cs_constraints();
-        remainingS.generate_r1cs_constraints();
-        fillAmountS.generate_r1cs_constraints();
-        fillAmountB.generate_r1cs_constraints();
+        fillAmount.generate_r1cs_constraints();
+        fillLimitBeforeCancelled.generate_r1cs_constraints();
+        fillLimit.generate_r1cs_constraints();
+        filledAfter.generate_r1cs_constraints();
+        filledAfter_leq_fillLimit.generate_r1cs_constraints();
     }
 
-    // fillAmountS uses NUM_BITS_AMOUNT bits max
-    const VariableT& getFillAmountS()
+    const VariableT& getFilledAfter() const
     {
-        return fillAmountS.result();
-    }
-
-    // fillAmountB uses NUM_BITS_AMOUNT bits max
-    const VariableT& getFillAmountB()
-    {
-        return fillAmountB.result();
+        return filledAfter.result();
     }
 };
 
-struct Amounts
-{
-    const VariableT amountS;
-    const VariableT amountB;
-};
-
-struct Fill
-{
-    const VariableT S;
-    const VariableT B;
-};
-
-// Calculates the settlement fill amounts of 2 orders
-class TakerMakerMatchingGadget : public GadgetT
+// Checks if the order requirements are fulfilled with the given fill amounts
+class RequireOrderFillsGadget : public GadgetT
 {
 public:
+    // Check balance limit
+    RequireLeqGadget fillS_leq_balanceS;
+    // Check rate
+    RequireFillRateGadget requireFillRate;
+    // Check fill limit
+    RequireFillLimitGadget requireFillLimit;
 
-    LeqGadget takerFillB_lt_makerFillS;
-
-    TernaryGadget value;
-    TernaryGadget numerator;
-    TernaryGadget denominator;
-    MulDivGadget newFill;
-
-    TernaryGadget makerFillS;
-    TernaryGadget makerFillB;
-    TernaryGadget takerFillS;
-    TernaryGadget takerFillB;
-
-    LeqGadget bMatchable;
-
-    TakerMakerMatchingGadget(
+    RequireOrderFillsGadget(
         ProtoboardT& pb,
         const Constants& constants,
-        const Amounts& takerOrder,
-        const Fill& takerFill,
-        const Amounts& makerOrder,
-        const Fill& makerFill,
+        const OrderGadget& order,
+        const VariableT& fillS,
+        const VariableT& fillB,
         const std::string& prefix
     ) :
         GadgetT(pb, prefix),
 
-        takerFillB_lt_makerFillS(pb, takerFill.B, makerFill.S, NUM_BITS_AMOUNT, FMT(prefix, ".takerFill.B < makerFill.S")),
-
-        // Do a single MulDiv for both case:
-        // - if takerFill.B < makerFill.S: takerFill.B * makerOrder.amountB // makerOrder.amountS
-        // - else: makerFill.S * takerOrder.amountS // takerOrder.amountB
-        value(pb, takerFillB_lt_makerFillS.lt(), takerFill.B, makerFill.S, FMT(prefix, ".value")),
-        numerator(pb, takerFillB_lt_makerFillS.lt(), makerOrder.amountB, takerOrder.amountS, FMT(prefix, ".numerator")),
-        denominator(pb, takerFillB_lt_makerFillS.lt(), makerOrder.amountS, takerOrder.amountB, FMT(prefix, ".denominator")),
-        newFill(pb, constants, value.result(), numerator.result(), denominator.result(), NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, FMT(prefix, ".newFill")),
-
-        makerFillS(pb, takerFillB_lt_makerFillS.lt(), takerFill.B, makerFill.S, FMT(prefix, ".makerFillS")),
-        makerFillB(pb, takerFillB_lt_makerFillS.lt(), newFill.result(), makerFill.B, FMT(prefix, ".makerFillB")),
-        takerFillS(pb, takerFillB_lt_makerFillS.lt(), takerFill.S, newFill.result(), FMT(prefix, ".takerFillS")),
-        takerFillB(pb, takerFillB_lt_makerFillS.lt(), takerFill.B, makerFill.S, FMT(prefix, ".takerFillB")),
-
-        bMatchable(pb, makerFillB.result(), takerFillS.result(), NUM_BITS_AMOUNT, FMT(prefix, ".bMatchable"))
+        // Check balance
+        fillS_leq_balanceS(pb, fillS, order.balanceSBefore.balance, NUM_BITS_AMOUNT, FMT(prefix, ".fillS_leq_balanceS")),
+        // Check rate
+        requireFillRate(pb, constants, order.amountS.packed, order.amountB.packed, fillS, fillB, NUM_BITS_AMOUNT, FMT(prefix, ".requireFillRate")),
+        // Check fill limit
+        requireFillLimit(pb, constants, order, fillS, fillB,  FMT(prefix, ".requireFillLimit"))
     {
 
     }
 
     void generate_r1cs_witness()
     {
-        takerFillB_lt_makerFillS.generate_r1cs_witness();
-
-        value.generate_r1cs_witness();
-        numerator.generate_r1cs_witness();
-        denominator.generate_r1cs_witness();
-        newFill.generate_r1cs_witness();
-
-        makerFillS.generate_r1cs_witness();
-        makerFillB.generate_r1cs_witness();
-        takerFillS.generate_r1cs_witness();
-        takerFillB.generate_r1cs_witness();
-
-        bMatchable.generate_r1cs_witness();
+        fillS_leq_balanceS.generate_r1cs_witness();
+        requireFillRate.generate_r1cs_witness();
+        requireFillLimit.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
     {
-        takerFillB_lt_makerFillS.generate_r1cs_constraints();
-
-        value.generate_r1cs_constraints();
-        numerator.generate_r1cs_constraints();
-        denominator.generate_r1cs_constraints();
-        newFill.generate_r1cs_constraints();
-
-        makerFillS.generate_r1cs_constraints();
-        makerFillB.generate_r1cs_constraints();
-        takerFillS.generate_r1cs_constraints();
-        takerFillB.generate_r1cs_constraints();
-
-        bMatchable.generate_r1cs_constraints();
+        fillS_leq_balanceS.generate_r1cs_constraints();
+        requireFillRate.generate_r1cs_constraints();
+        requireFillLimit.generate_r1cs_constraints();
     }
 
-    const VariableT& getTakerFillS() const
+    const VariableT& getFilledAfter() const
     {
-        return takerFillS.result();
-    }
-
-    const VariableT& getTakerFillB() const
-    {
-        return takerFillB.result();
-    }
-
-    const VariableT& getMakerFillS() const
-    {
-        return makerFillS.result();
-    }
-
-    const VariableT& getMakerFillB() const
-    {
-        return makerFillB.result();
-    }
-
-    const VariableT& isMatchable() const
-    {
-        return bMatchable.leq();
-    }
-};
-
-// Does TakerMakerMatchingGadget(orderA, orderB) if orderA is a buy order (with fillA.S = fillB.B),
-// else TakerMakerMatchingGadget(orderB, orderA) (with fillA.B = fillB.S)
-class MatchingGadget : public GadgetT
-{
-public:
-    TernaryGadget takerAmountS;
-    TernaryGadget takerAmountB;
-    TernaryGadget takerFillS;
-    TernaryGadget takerFillB;
-
-    TernaryGadget makerAmountS;
-    TernaryGadget makerAmountB;
-    TernaryGadget makerFillS;
-    TernaryGadget makerFillB;
-
-    TakerMakerMatchingGadget matchingGadget;
-
-    TernaryGadget fillA_S;
-    TernaryGadget fillA_B;
-    TernaryGadget fillB_S;
-    TernaryGadget fillB_B;
-
-    MatchingGadget(
-        ProtoboardT& pb,
-        const Constants& constants,
-        const OrderGadget& orderA,
-        const Fill inFillA,
-        const OrderGadget& orderB,
-        const Fill inFillB,
-        const std::string& prefix
-    ) :
-        GadgetT(pb, prefix),
-
-        takerAmountS(pb, orderA.buy.packed, orderA.amountS.packed, orderB.amountS.packed, FMT(prefix, ".takerAmountS")),
-        takerAmountB(pb, orderA.buy.packed, orderA.amountB.packed, orderB.amountB.packed, FMT(prefix, ".takerAmountB")),
-        takerFillS(pb, orderA.buy.packed, inFillA.S, inFillB.S, FMT(prefix, ".takerFillS")),
-        takerFillB(pb, orderA.buy.packed, inFillA.B, inFillB.B, FMT(prefix, ".takerFillB")),
-
-        makerAmountS(pb, orderA.buy.packed, orderB.amountS.packed, orderA.amountS.packed, FMT(prefix, ".makerAmountS")),
-        makerAmountB(pb, orderA.buy.packed, orderB.amountB.packed, orderA.amountB.packed, FMT(prefix, ".makerAmountB")),
-        makerFillS(pb, orderA.buy.packed, inFillB.S, inFillA.S, FMT(prefix, ".makerFillS")),
-        makerFillB(pb, orderA.buy.packed, inFillB.B, inFillA.B, FMT(prefix, ".makerFillB")),
-
-        matchingGadget(pb, constants,
-                       {takerAmountS.result(), takerAmountB.result()}, {takerFillS.result(), takerFillB.result()},
-                       {makerAmountS.result(), makerAmountB.result()}, {makerFillS.result(), makerFillB.result()},
-                       FMT(prefix, ".matchingGadget")),
-
-        fillA_S(pb, orderA.buy.packed, matchingGadget.getMakerFillB(), matchingGadget.getMakerFillS(), FMT(prefix, ".fillA_S")),
-        fillA_B(pb, orderA.buy.packed, matchingGadget.getTakerFillB(), matchingGadget.getTakerFillS(), FMT(prefix, ".fillA_B")),
-        fillB_S(pb, orderA.buy.packed, matchingGadget.getMakerFillS(), matchingGadget.getTakerFillS(), FMT(prefix, ".fillB_S")),
-        fillB_B(pb, orderA.buy.packed, matchingGadget.getMakerFillB(), matchingGadget.getTakerFillB(), FMT(prefix, ".fillB_B"))
-    {
-
-    }
-
-    void generate_r1cs_witness()
-    {
-        takerAmountS.generate_r1cs_witness();
-        takerAmountB.generate_r1cs_witness();
-        takerFillS.generate_r1cs_witness();
-        takerFillB.generate_r1cs_witness();
-
-        makerAmountS.generate_r1cs_witness();
-        makerAmountB.generate_r1cs_witness();
-        makerFillS.generate_r1cs_witness();
-        makerFillB.generate_r1cs_witness();
-
-        matchingGadget.generate_r1cs_witness();
-
-        fillA_S.generate_r1cs_witness();
-        fillA_B.generate_r1cs_witness();
-        fillB_S.generate_r1cs_witness();
-        fillB_B.generate_r1cs_witness();
-    }
-
-    void generate_r1cs_constraints()
-    {
-        takerAmountS.generate_r1cs_constraints();
-        takerAmountB.generate_r1cs_constraints();
-        takerFillS.generate_r1cs_constraints();
-        takerFillB.generate_r1cs_constraints();
-
-        makerAmountS.generate_r1cs_constraints();
-        makerAmountB.generate_r1cs_constraints();
-        makerFillS.generate_r1cs_constraints();
-        makerFillB.generate_r1cs_constraints();
-
-        matchingGadget.generate_r1cs_constraints();
-
-        fillA_S.generate_r1cs_constraints();
-        fillA_B.generate_r1cs_constraints();
-        fillB_S.generate_r1cs_constraints();
-        fillB_B.generate_r1cs_constraints();
-    }
-
-    const VariableT& getFillA_S() const
-    {
-        return fillA_S.result();
-    }
-
-    const VariableT& getFillA_B() const
-    {
-        return fillA_B.result();
-    }
-
-    const VariableT& getFillB_S() const
-    {
-        return fillB_S.result();
-    }
-
-    const VariableT& getFillB_B() const
-    {
-        return fillB_B.result();
-    }
-
-    const VariableT& isMatchable() const
-    {
-        return matchingGadget.isMatchable();
-    }
-};
-
-// LimitFillCalculationGadget use FillS_A(taker_sale) and maker's price to calculate FillS_B(maker sale)
-// which should equal to input fillS_B.
-// 1. check iff inFillS_A <= maxFillS_A & inFillS_B <= maxFillS_B
-// 2. use maker's price to calc FillS_B
-// 3. make sure newFillS_B == inFillS_B
-class LimitFillCalculationGadget : public GadgetT
-{
-public:
-    const FloatGadget& fillS_A;
-    const FloatGadget& fillS_B;
-
-    LeqGadget       validFillS_A;
-    LeqGadget       validFillS_B;
-    MulDivGadget    newFillS_B;
-    FloatGadget     uFillS_B;
-    EqualGadget     uFillS_B_eq_inFillS_B;
-    AndGadget       valid;
-
-    LimitFillCalculationGadget(
-        ProtoboardT& pb,
-        const Constants& constants,
-        const VariableT& maxFillS_A,
-        const VariableT& maxFillS_B,
-        const FloatGadget& inFillS_A,
-        const FloatGadget& inFillS_B,
-        const OrderGadget& orderB,
-        const std::string& prefix
-    ) :
-        GadgetT(pb, prefix),
-
-        fillS_A(inFillS_A),
-        fillS_B(inFillS_B),
-
-        validFillS_A(pb, inFillS_A.value(), maxFillS_A, NUM_BITS_AMOUNT, FMT(prefix, ".validFillS_A(inputFillS_A <= maxFillS_A")),
-        validFillS_B(pb, inFillS_B.value(), maxFillS_B, NUM_BITS_AMOUNT, FMT(prefix, ".validFillS_B(inputFillS_B <= maxFillS_B")),
-
-        newFillS_B(pb, constants, fillS_A.value(), orderB.amountS.packed, orderB.amountB.packed, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, NUM_BITS_AMOUNT, FMT(prefix, ".newFillS_B")),
-
-        uFillS_B(pb, constants, Float24Encoding, FMT(prefix, ".uFillS_B")),
-
-        uFillS_B_eq_inFillS_B(pb, uFillS_B.value(), fillS_B.value(), FMT(prefix, ".uFillS_B_eq_inFillS_B")),
-
-        valid(pb, {validFillS_A.leq(), validFillS_B.leq(), uFillS_B_eq_inFillS_B.result()}, FMT(prefix, ".valid"))
-    {
-    }
-
-    void generate_r1cs_witness()
-    {
-        validFillS_A.generate_r1cs_witness();
-        validFillS_B.generate_r1cs_witness();
-        newFillS_B.generate_r1cs_witness();
-        uFillS_B.generate_r1cs_witness(toFloat(pb.val(newFillS_B.result()), Float24Encoding));
-        uFillS_B_eq_inFillS_B.generate_r1cs_witness();
-        valid.generate_r1cs_witness();
-    }
-
-    void generate_r1cs_constraints()
-    {
-        validFillS_A.generate_r1cs_constraints();
-        validFillS_B.generate_r1cs_constraints();
-        newFillS_B.generate_r1cs_constraints();
-        uFillS_B.generate_r1cs_constraints();
-        uFillS_B_eq_inFillS_B.generate_r1cs_constraints();
-        valid.generate_r1cs_constraints();
-    }
-
-    const VariableT& getFillA_S() const
-    {
-        return fillS_A.value();
-    }
-
-    const VariableT& getFillA_B() const
-    {
-        return uFillS_B.value();
-    }
-
-    const VariableT& getFillB_S() const
-    {
-        return uFillS_B.value();
-    }
-
-    const VariableT& getFillB_B() const
-    {
-        return fillS_A.value();
-    }
-
-    const VariableT& isValid() const
-    {
-        return valid.result();
+        return requireFillLimit.getFilledAfter();
     }
 };
 
@@ -677,15 +355,12 @@ class OrderMatchingGadget : public GadgetT
 {
 public:
 
-    // Get the max amount the orders can be filled
-    MaxFillAmountsGadget maxFillAmountA;
-    MaxFillAmountsGadget maxFillAmountB;
+    const VariableT& fillS_A;
+    const VariableT& fillS_B;
 
-    // Match the orders
-    MatchingGadget matchingGadget;
-
-    // 2-pass match to clamp S/B amount.
-    LimitFillCalculationGadget limitFillCalculationGadget;
+    // Verify the order fills
+    RequireOrderFillsGadget requireOrderFillsA;
+    RequireOrderFillsGadget requireOrderFillsB;
 
     // Check if tokenS/tokenB match
     RequireEqualGadget orderA_tokenS_eq_orderB_tokenB;
@@ -695,6 +370,7 @@ public:
     CheckValidGadget checkValidA;
     CheckValidGadget checkValidB;
     AndGadget valid;
+    RequireEqualGadget requireValid;
 
     OrderMatchingGadget(
         ProtoboardT& pb,
@@ -702,48 +378,36 @@ public:
         const VariableT& timestamp,
         const OrderGadget& orderA,
         const OrderGadget& orderB,
-        const FloatGadget& fillS_A,
-        const FloatGadget& fillS_B,
+        const VariableT& _fillS_A,
+        const VariableT& _fillS_B,
         const std::string& prefix
     ) :
         GadgetT(pb, prefix),
+        fillS_A(_fillS_A),
+        fillS_B(_fillS_B),
 
-        // Get the max amount the orders can be filled
-        maxFillAmountA(pb, constants, orderA, FMT(prefix, ".maxFillAmountA")),
-        maxFillAmountB(pb, constants, orderB, FMT(prefix, ".maxFillAmountB")),
-
-        // Match the orders
-        matchingGadget(pb, constants,
-                       orderA, {maxFillAmountA.getFillAmountS(), maxFillAmountA.getFillAmountB()},
-                       orderB, {maxFillAmountB.getFillAmountS(), maxFillAmountB.getFillAmountB()},
-                       FMT(prefix, ".matchingGadget")),
-
-        // use input fillS_A to calculate order fillS_B and which should eq input fillS_B
-        limitFillCalculationGadget(pb, constants, matchingGadget.getFillA_S(), matchingGadget.getFillB_S(), fillS_A, fillS_B, orderB, FMT(prefix, ".limitFillCalculationGadget")),
+        // Check if the fills are valid for the orders
+        requireOrderFillsA(pb, constants, orderA, fillS_A, fillS_B, FMT(prefix, ".requireOrderFillsA")),
+        requireOrderFillsB(pb, constants, orderB, fillS_B, fillS_A, FMT(prefix, ".requireOrderFillsB")),
 
         // Check if tokenS/tokenB match
         orderA_tokenS_eq_orderB_tokenB(pb, orderA.tokenS.packed, orderB.tokenB.packed, FMT(prefix, ".orderA_tokenS_eq_orderB_tokenB")),
         orderA_tokenB_eq_orderB_tokenS(pb, orderA.tokenB.packed, orderB.tokenS.packed, FMT(prefix, ".orderA_tokenB_eq_orderB_tokenS")),
 
         // Check if the orders in the settlement are correctly filled
-        checkValidA(pb, constants, timestamp, orderA, limitFillCalculationGadget.getFillA_S(), limitFillCalculationGadget.getFillA_B(), FMT(prefix, ".checkValidA")),
-        checkValidB(pb, constants, timestamp, orderB, limitFillCalculationGadget.getFillB_S(), limitFillCalculationGadget.getFillB_B(), FMT(prefix, ".checkValidB")),
-        valid(pb, {matchingGadget.isMatchable(), limitFillCalculationGadget.isValid(), checkValidA.isValid(), checkValidB.isValid()}, FMT(prefix, ".valid"))
+        checkValidA(pb, constants, timestamp, orderA, fillS_A, fillS_B, FMT(prefix, ".checkValidA")),
+        checkValidB(pb, constants, timestamp, orderB, fillS_B, fillS_A, FMT(prefix, ".checkValidB")),
+        valid(pb, {checkValidA.isValid(), checkValidB.isValid()}, FMT(prefix, ".valid")),
+        requireValid(pb, valid.result(), constants.one, FMT(prefix, ".requireValid"))
     {
 
     }
 
     void generate_r1cs_witness()
     {
-        // Get the max amount the orders can be filled
-        maxFillAmountA.generate_r1cs_witness();
-        maxFillAmountB.generate_r1cs_witness();
-
-        // Match the orders
-        matchingGadget.generate_r1cs_witness();
-
-        // 2 pass to calc the fillS/B
-        limitFillCalculationGadget.generate_r1cs_witness();
+        // Check if the fills are valid for the orders
+        requireOrderFillsA.generate_r1cs_witness();
+        requireOrderFillsB.generate_r1cs_witness();
 
         // Check if tokenS/tokenB match
         orderA_tokenS_eq_orderB_tokenB.generate_r1cs_witness();
@@ -753,19 +417,14 @@ public:
         checkValidA.generate_r1cs_witness();
         checkValidB.generate_r1cs_witness();
         valid.generate_r1cs_witness();
+        requireValid.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
     {
-        // Get the max amount the orders can be filled
-        maxFillAmountA.generate_r1cs_constraints();
-        maxFillAmountB.generate_r1cs_constraints();
-
-        // Match the orders
-        matchingGadget.generate_r1cs_constraints();
-
-        // 2 pass to calc the fillS/B
-        limitFillCalculationGadget.generate_r1cs_constraints();
+        // Check if the fills are valid for the orders
+        requireOrderFillsA.generate_r1cs_constraints();
+        requireOrderFillsB.generate_r1cs_constraints();
 
         // Check if tokenS/tokenB match
         orderA_tokenS_eq_orderB_tokenB.generate_r1cs_constraints();
@@ -775,31 +434,37 @@ public:
         checkValidA.generate_r1cs_constraints();
         checkValidB.generate_r1cs_constraints();
         valid.generate_r1cs_constraints();
+        requireValid.generate_r1cs_constraints();
     }
 
     const VariableT& getFillA_S() const
     {
-        return limitFillCalculationGadget.getFillA_S();
+        return fillS_A;
     }
 
     const VariableT& getFillA_B() const
     {
-        return limitFillCalculationGadget.getFillA_B();
+        return fillS_B;
     }
 
     const VariableT& getFillB_S() const
     {
-        return limitFillCalculationGadget.getFillB_S();
+        return fillS_B;
     }
 
     const VariableT& getFillB_B() const
     {
-        return limitFillCalculationGadget.getFillB_B();
+        return fillS_A;
     }
 
-    const VariableT& isValid() const
+    const VariableT& getFilledAfter_A() const
     {
-        return valid.result();
+        return requireOrderFillsA.getFilledAfter();
+    }
+
+    const VariableT& getFilledAfter_B() const
+    {
+        return requireOrderFillsB.getFilledAfter();
     }
 };
 

--- a/Gadgets/MatchingGadgets.h
+++ b/Gadgets/MatchingGadgets.h
@@ -390,7 +390,7 @@ public:
     ) :
         GadgetT(pb, prefix),
 
-        takerFillB_lt_makerFillS(pb, takerFill.B, makerFill.S, NUM_BITS_AMOUNT, FMT(prefix, ".takerFill.B < makerFill.B")),
+        takerFillB_lt_makerFillS(pb, takerFill.B, makerFill.S, NUM_BITS_AMOUNT, FMT(prefix, ".takerFill.B < makerFill.S")),
 
         // Do a single MulDiv for both case:
         // - if takerFill.B < makerFill.S: takerFill.B * makerOrder.amountB // makerOrder.amountS

--- a/Gadgets/MathGadgets.h
+++ b/Gadgets/MathGadgets.h
@@ -29,8 +29,8 @@ class Constants : public GadgetT
 public:
     const VariableT zero;
     const VariableT one;
-    const VariableT _100;
-    const VariableT _101;
+    const VariableT _1000;
+    const VariableT _1001;
     const VariableT _10000;
     const VariableT _100000;
     const VariableT emptyTradeHistory;
@@ -47,8 +47,8 @@ public:
 
         zero(make_variable(pb, FieldT::zero(), FMT(prefix, ".zero"))),
         one(make_variable(pb, FieldT::one(), FMT(prefix, ".one"))),
-        _100(make_variable(pb, ethsnarks::FieldT(100), FMT(prefix, "._100"))),
-        _101(make_variable(pb, ethsnarks::FieldT(101), FMT(prefix, "._101"))),
+        _1000(make_variable(pb, ethsnarks::FieldT(1000), FMT(prefix, "._1000"))),
+        _1001(make_variable(pb, ethsnarks::FieldT(1001), FMT(prefix, "._1001"))),
         _10000(make_variable(pb, ethsnarks::FieldT(10000), FMT(prefix, "._10000"))),
         _100000(make_variable(pb, ethsnarks::FieldT(100000), FMT(prefix, "._100000"))),
         emptyTradeHistory(make_variable(pb, ethsnarks::FieldT(EMPTY_TRADE_HISTORY), FMT(prefix, ".emptyTradeHistory"))),
@@ -69,8 +69,8 @@ public:
     {
         pb.add_r1cs_constraint(ConstraintT(zero, FieldT::one(), FieldT::zero()), ".zero");
         pb.add_r1cs_constraint(ConstraintT(one, FieldT::one(), FieldT::one()), ".one");
-        pb.add_r1cs_constraint(ConstraintT(_100, FieldT::one(), ethsnarks::FieldT(100)), "._100");
-        pb.add_r1cs_constraint(ConstraintT(_101, FieldT::one(), ethsnarks::FieldT(101)), "._101");
+        pb.add_r1cs_constraint(ConstraintT(_1000, FieldT::one(), ethsnarks::FieldT(1000)), "._1000");
+        pb.add_r1cs_constraint(ConstraintT(_1001, FieldT::one(), ethsnarks::FieldT(1001)), "._1001");
         pb.add_r1cs_constraint(ConstraintT(_10000, FieldT::one(), ethsnarks::FieldT(10000)), "._10000");
         pb.add_r1cs_constraint(ConstraintT(_100000, FieldT::one(), ethsnarks::FieldT(100000)), "._100000");
         pb.add_r1cs_constraint(ConstraintT(emptyTradeHistory, FieldT::one(), ethsnarks::FieldT(EMPTY_TRADE_HISTORY)), ".emptyTradeHistory");

--- a/Utils/Data.h
+++ b/Utils/Data.h
@@ -210,12 +210,16 @@ class Ring
 public:
     Order orderA;
     Order orderB;
+    ethsnarks::FieldT fillS_A;
+    ethsnarks::FieldT fillS_B;
 };
 
 static void from_json(const json& j, Ring& ring)
 {
     ring.orderA = j.at("orderA").get<Order>();
     ring.orderB = j.at("orderB").get<Order>();
+    ring.fillS_A = ethsnarks::FieldT(j["fFillS_A"]);
+    ring.fillS_B = ethsnarks::FieldT(j["fFillS_B"]);
 }
 
 class RingSettlement

--- a/Utils/Utils.h
+++ b/Utils/Utils.h
@@ -156,6 +156,12 @@ static BigInt fromFloat(unsigned int f, const FloatEncoding& encoding)
     return value;
 }
 
+static FieldT roundToFloatValue(const FieldT& value, const FloatEncoding& encoding) {
+  auto f = toFloat(value, encoding);
+  auto floatValue = fromFloat(f, encoding);
+  return FieldT(floatValue.to_string().c_str());
+}
+
 }
 
 #endif


### PR DESCRIPTION
Builds on #25 

But implements things like explained [here](https://github.com/Loopring/protocol3-circuits/pull/25#issuecomment-549092484).

The fill amounts passed into the circuits are ALWAYS used as is. **That means that invalid rings cannot be included in the circuit any more (previously the fill amounts were set to 0 for invalid rings). Either the passed in `fillS_A` and `fillS_B` values are valid or the ring cannot be included in the circuit. `fillS_A == 0` or `fillS_B = 0` is also not allowed!** (@hosschao please notice this)

Valid fill amounts are just fill amounts that respect the requirements of the order. No other rules are enforced.


