### PR TITLE
do validate in prove mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -514,7 +514,7 @@ int main (int argc, char **argv)
         }
     }
 
-    if (mode == Mode::Validate)
+    if (mode == Mode::Validate || mode == Mode::Prove)
     {
         // Check if the inputs are valid for the circuit
         if (!pb.is_satisfied())


### PR DESCRIPTION
Fix the bug we encountered yesterday: 
a block json file can generate proofs successfully but failed to do validating.